### PR TITLE
Implement Abdelrahman Add Connection UI scenarios and JES Explorer wrapper

### DIFF
--- a/src/uiTest/kotlin/tests/AddConnectionDialogTest.kt
+++ b/src/uiTest/kotlin/tests/AddConnectionDialogTest.kt
@@ -15,25 +15,31 @@
 
 package tests
 
-import io.kotest.core.annotation.Description
 import com.intellij.driver.client.Driver
+import com.intellij.driver.sdk.ui.components.*
+import io.kotest.core.annotation.Description
 import okhttp3.mockwebserver.MockResponse
 import org.junit.jupiter.api.*
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Assertions.assertTrue
 import tests.utils.*
+import tests.utils.uidefinitions.ActionMenuPoints
 import tests.utils.uidefinitions.dialogs.AddConnectionDialog
-import tests.utils.uidefinitions.dialogs.UnsecureConnectionDialog
 import tests.utils.uidefinitions.FilesExplorerPanel
-import tests.utils.uidefinitions.dialogs.ErrorCreatingConnectionDialog
+import tests.utils.uidefinitions.JesExplorerPanel
 
-@Disabled("This testsuite needs to be reworked")
 @Description("Tests for interaction and filling the connection creation dialog")
 class AddConnectionDialogTest {
-  private lateinit var filesExplorerPanel: FilesExplorerPanel
-  private lateinit var addConnectionDialog: AddConnectionDialog
-  private lateinit var unsecureConnectionDialog: UnsecureConnectionDialog
-  private lateinit var errorCreatingConnectionDialog: ErrorCreatingConnectionDialog
-
   companion object {
+    private const val CONNECTIONS_TAB = "Connections"
+    private const val TEST_USERNAME = "test"
+    private const val TEST_USERNAME_2 = "test2"
+    private const val TEST_PASSWORD = "test"
+
+    private const val CASE_1_CONNECTION = "test_valid_connection_1"
+    private const val CASE_2_CONNECTION = "test_valid_connection_2"
+    private const val CASE_4_CONNECTION = "test_valid_connection_3"
+
     private lateinit var ideDriver: Driver
 
     @JvmStatic
@@ -42,8 +48,9 @@ class AddConnectionDialogTest {
       IdeRunManager.prepareRunManager()
         .runningIde
         .resetTestEnv()
-      val ideDriver = IdeRunManager.getIdeDriver()
+      ideDriver = IdeRunManager.getIdeDriver()
       openZoweExplorerPanel(ideDriver)
+      deleteConfigEntities(ideDriver, CONNECTIONS_TAB)
     }
 
     @JvmStatic
@@ -52,54 +59,28 @@ class AddConnectionDialogTest {
       IdeRunManager.prepareRunManager()
         .runningIde
         .resetTestEnv()
-      deleteConfigEntities(ideDriver, "Connections")
+      deleteConfigEntities(ideDriver, CONNECTIONS_TAB)
       MockWebServerManager.removeAllEndpoints()
     }
   }
 
   @BeforeEach
   fun prepareTestEnv() {
-    filesExplorerPanel = FilesExplorerPanel(ideDriver)
-    addConnectionDialog = AddConnectionDialog(ideDriver)
-    unsecureConnectionDialog = UnsecureConnectionDialog(ideDriver)
-    errorCreatingConnectionDialog = ErrorCreatingConnectionDialog(ideDriver)
+    IdeRunManager.prepareRunManager()
+      .runningIde
+      .resetTestEnv()
   }
 
   @AfterEach
   fun finalizeTestEnv() {
+    IdeRunManager.prepareRunManager()
+      .runningIde
+      .resetTestEnv()
+    deleteConfigEntities(ideDriver, CONNECTIONS_TAB)
     MockWebServerManager.removeAllEndpoints()
   }
 
-  // Some helping instructions:
-  //    filesExplorerPanel.createInvalidConnection(ideDriver, connectionName)
-  //    addConnectionDialog
-  //      .fillDialog(
-  //        connectionName = "nameInput",
-  //        connectionUrl = "https://${mockServer.hostName}:${mockServer.port}",
-  //        username = "userNameInput",
-  //        password = "passwordInput",
-  //        isAcceptSelfSigned = true
-  //      )
-  //
-  //    unsecureConnectionDialog.proceedButton.click()
-  //    addConnectionDialog.okButton.click()
-  //    unsecureConnectionDialog.proceedButton.click()
-
-  //    assert(errorCreatingConnectionDialog.dialogComponent.isVisible())
-  //
-  //    errorCreatingConnectionDialog.noButton.click()
-
-  /**
-   * For Abdelrahman El Banna
-   * @see
-   * <a href="https://github.com/zowe/zowe-explorer-intellij/wiki/Manual-and-automated-test-cases-consistency#-add-valid-connection">
-   *   Regression: Add valid connection
-   * </a>
-   */
-  @Test
-  @Tag("New")
-  fun createValidConnectionTest(testInfo: TestInfo) {
-    // Success scenario:
+  private fun injectSuccessfulConnectionEndpoints(testInfo: TestInfo) {
     MockWebServerManager.injectEndpoint(
       "${testInfo.displayName}_info",
       jsonMock = "infoResponse",
@@ -112,6 +93,149 @@ class AddConnectionDialogTest {
     )
   }
 
+  private fun assertConnectionsInSettings(
+    expectedRowsCount: Int,
+    expectedConnectionNames: List<String>,
+    expectedUsernames: List<String>
+  ) {
+    val settingsDialog = goToSettings(ideDriver, CONNECTIONS_TAB)
+    ideDriver.ideFrame {
+      val connectionsTable = settingsDialog.table { byClass("ValidatingTableView") }
+      assertEquals(expectedRowsCount, connectionsTable.rowCount())
+      val tableText = settingsDialog.x { byClass("ValidatingTableView") }.allTextAsString()
+      val normalizedTableText = tableText.uppercase()
+      expectedConnectionNames.forEach { expectedName ->
+        assertTrue(tableText.contains(expectedName), "Expected connection '$expectedName' to be present in Settings")
+      }
+      expectedUsernames.forEach { expectedUsername ->
+        assertTrue(
+          normalizedTableText.contains(expectedUsername.uppercase()),
+          "Expected username '$expectedUsername' to be present in Settings"
+        )
+      }
+      settingsDialog.actionButton { byVisibleText("OK") }.click()
+    }
+  }
+
+  private fun assertSingleConnectionValuesInEditDialog(
+    expectedConnectionName: String,
+    expectedUrl: String,
+    expectedUsername: String
+  ) {
+    val settingsDialog = goToSettings(ideDriver, CONNECTIONS_TAB)
+    ideDriver.ideFrame {
+      val connectionsTable = settingsDialog.table { byClass("ValidatingTableView") }
+      assertEquals(1, connectionsTable.rowCount())
+      connectionsTable.doubleClickCell(0, 0)
+
+      val editConnectionDialog = AddConnectionDialog(ideDriver)
+      assertEquals(expectedConnectionName, editConnectionDialog.getConnectionNameValue())
+      assertEquals(expectedUrl, editConnectionDialog.getConnectionUrlValue())
+      assertEquals(expectedUsername.uppercase(), editConnectionDialog.getUsernameValue().uppercase())
+      editConnectionDialog.cancelButton.click()
+      settingsDialog.actionButton { byVisibleText("Cancel") }.click()
+    }
+  }
+
+  private fun deleteAllConnectionsInSettings() {
+    IdeRunManager.prepareRunManager()
+      .runningIde
+      .resetTestEnv()
+    deleteConfigEntities(ideDriver, CONNECTIONS_TAB)
+  }
+
+  /**
+   * For Abdelrahman El Banna
+   * @see
+   * <a href="https://github.com/zowe/zowe-explorer-intellij/wiki/Manual-and-automated-test-cases-consistency#-add-valid-connection">
+   *   Regression: Add valid connection
+   * </a>
+   */
+  @Test
+  @Tag("New")
+  fun createValidConnectionTest(testInfo: TestInfo) {
+    injectSuccessfulConnectionEndpoints(testInfo)
+
+    // Case 1: valid connection via Files Explorer.
+    FilesExplorerPanel(ideDriver).createValidConnection(
+      ideDriver = ideDriver,
+      connectionName = CASE_1_CONNECTION,
+      username = TEST_USERNAME,
+      password = TEST_PASSWORD
+    )
+    assertConnectionsInSettings(
+      expectedRowsCount = 1,
+      expectedConnectionNames = listOf(CASE_1_CONNECTION),
+      expectedUsernames = listOf(TEST_USERNAME)
+    )
+    deleteAllConnectionsInSettings()
+
+    // Case 2: valid connection via JES Explorer with trailing spaces in some fields.
+    val connectionUrlWithTrailingSpaces = "${MockWebServerManager.url}    "
+    val jesExplorerPanel = JesExplorerPanel(ideDriver)
+    jesExplorerPanel.openDialogByPlusButtonInExplorer(ActionMenuPoints.CONNECTION)
+    val addConnectionDialog = AddConnectionDialog(ideDriver)
+    addConnectionDialog.fillDialog(
+      connectionName = "$CASE_2_CONNECTION    ",
+      connectionUrl = connectionUrlWithTrailingSpaces,
+      username = "$TEST_USERNAME    ",
+      password = TEST_PASSWORD,
+      isAcceptSelfSigned = false
+    )
+    addConnectionDialog.okButton.click()
+    assertConnectionsInSettings(
+      expectedRowsCount = 1,
+      expectedConnectionNames = listOf(CASE_2_CONNECTION),
+      expectedUsernames = listOf(TEST_USERNAME)
+    )
+    assertSingleConnectionValuesInEditDialog(
+      expectedConnectionName = CASE_2_CONNECTION,
+      expectedUrl = MockWebServerManager.url,
+      expectedUsername = TEST_USERNAME
+    )
+    deleteAllConnectionsInSettings()
+
+    // Case 3: valid connection with 200-character name.
+    val longConnectionName = "B".repeat(200)
+    FilesExplorerPanel(ideDriver).createValidConnection(
+      ideDriver = ideDriver,
+      connectionName = longConnectionName,
+      username = TEST_USERNAME,
+      password = TEST_PASSWORD
+    )
+    assertConnectionsInSettings(
+      expectedRowsCount = 1,
+      expectedConnectionNames = emptyList(),
+      expectedUsernames = listOf(TEST_USERNAME)
+    )
+    assertSingleConnectionValuesInEditDialog(
+      expectedConnectionName = longConnectionName,
+      expectedUrl = MockWebServerManager.url,
+      expectedUsername = TEST_USERNAME
+    )
+    deleteAllConnectionsInSettings()
+
+    // Case 4: adding another connection with different username is allowed.
+    val filesExplorerPanel = FilesExplorerPanel(ideDriver)
+    filesExplorerPanel.createValidConnection(
+      ideDriver = ideDriver,
+      connectionName = CASE_1_CONNECTION,
+      username = TEST_USERNAME,
+      password = TEST_PASSWORD
+    )
+    filesExplorerPanel.createValidConnection(
+      ideDriver = ideDriver,
+      connectionName = CASE_4_CONNECTION,
+      username = TEST_USERNAME_2,
+      password = TEST_PASSWORD
+    )
+    assertConnectionsInSettings(
+      expectedRowsCount = 2,
+      expectedConnectionNames = listOf(CASE_1_CONNECTION, CASE_4_CONNECTION),
+      expectedUsernames = listOf(TEST_USERNAME, TEST_USERNAME_2)
+    )
+  }
+
   /**
    * For Andres Pedreros Castro
    * @see
@@ -121,6 +245,7 @@ class AddConnectionDialogTest {
    */
   @Test
   @Tag("New")
+  @Disabled("Assigned to another scenario owner")
   fun createInvalidConnectionTest(testInfo: TestInfo) {
     // 401 Unauthorized (for wrong credentials):
     MockWebServerManager.injectEndpoint(
@@ -149,6 +274,7 @@ class AddConnectionDialogTest {
    */
   @Test
   @Tag("New")
+  @Disabled("Assigned to another scenario owner")
   fun editExistingConnectionTest(testInfo: TestInfo) {
     // Success scenario:
     MockWebServerManager.injectEndpoint(

--- a/src/uiTest/kotlin/tests/utils/navigation.kt
+++ b/src/uiTest/kotlin/tests/utils/navigation.kt
@@ -52,6 +52,39 @@ fun openZoweExplorerPanel(driver: Driver) {
 }
 
 /**
+ * Open a requested explorer tab in Zowe Explorer tool window.
+ * Handles the case when the tab is hidden under the chevron menu.
+ */
+private fun openExplorerTab(driver: Driver, tabName: String) {
+  openZoweExplorerPanel(driver)
+  driver.ideFrame {
+    val zoweExplorerTabs = x("//div[@class='ToolWindowHeader'][.//div[@class='BaseLabel' and @visible_text='Zowe Explorer']]")
+    val requestedTabPotentialElements = zoweExplorerTabs.xx { byText(tabName) }.list()
+    if (requestedTabPotentialElements.isNotEmpty()) {
+      val requestedTab = requestedTabPotentialElements[0]
+      requestedTab.setFocus()
+      requestedTab.click()
+      return@ideFrame
+    }
+
+    val chevronWithOtherTabs = zoweExplorerTabs
+      .actionButtonByXpath("//div[@class='ActionButton' and contains(@myicon,'chevron')]")
+    chevronWithOtherTabs.setFocus()
+    chevronWithOtherTabs.click()
+
+    val explorerTabsPopup = popup()
+    val explorerTabsPopupList = explorerTabsPopup.list("//div[@class='MyList']")
+    explorerTabsPopupList.clickItem(tabName)
+  }
+}
+
+/** Open the "File Explorer" tab in Zowe Explorer tool window */
+fun openFilesExplorerTab(driver: Driver) = openExplorerTab(driver, "File Explorer")
+
+/** Open the "JES Explorer" tab in Zowe Explorer tool window */
+fun openJesExplorerTab(driver: Driver) = openExplorerTab(driver, "JES Explorer")
+
+/**
  * Go to settings from any explorer view available by the [driver].
  * Will open the provided [tabName] or "Connections" as a default if is not provided
  * @return settings tab as a [DialogUiComponent]

--- a/src/uiTest/kotlin/tests/utils/uidefinitions/FilesExplorerPanel.kt
+++ b/src/uiTest/kotlin/tests/utils/uidefinitions/FilesExplorerPanel.kt
@@ -26,6 +26,7 @@ import java.awt.event.KeyEvent
 enum class ActionMenuPoints(val point: String) {
   CONNECTION("Connection"),
   WORKING_SET("Working Set"),
+  JES_WORKING_SET("JES Working Set"),
 }
 
 /** File explorer panel wrapper. Provides functionalities to work with File Explorer view elements */
@@ -41,6 +42,7 @@ class FilesExplorerPanel(val driver: Driver) {
   val plusButton by lazy { explorerView.actionButton { byAttribute("myicon", "add.svg") } }
 
   init {
+    openFilesExplorerTab(driver)
     driver.ideFrame {
       explorerView = x("//div[@class='SimpleToolWindowPanel' and div[@class='FileExplorerView']]")
       plusDropdownList = popup().list { byClass("MyList") }
@@ -57,7 +59,11 @@ class FilesExplorerPanel(val driver: Driver) {
    */
   fun openDialogByPlusButtonInExplorer(point: ActionMenuPoints) {
     plusButton.click()
-    if (point == ActionMenuPoints.CONNECTION || point == ActionMenuPoints.WORKING_SET) {
+    if (
+      point == ActionMenuPoints.CONNECTION ||
+      point == ActionMenuPoints.WORKING_SET ||
+      point == ActionMenuPoints.JES_WORKING_SET
+    ) {
       plusDropdownList.clickItem(point.point)
     } else {
       throw IllegalArgumentException("Unsupported point: $point")

--- a/src/uiTest/kotlin/tests/utils/uidefinitions/JesExplorerPanel.kt
+++ b/src/uiTest/kotlin/tests/utils/uidefinitions/JesExplorerPanel.kt
@@ -1,0 +1,119 @@
+/*
+ * This program and the accompanying materials are made available under the terms of the
+ * Eclipse Public License v2.0 which accompanies this distribution, and is available at
+ * https://www.eclipse.org/legal/epl-v20.html
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Copyright Contributors to the Zowe Project.
+ *
+ * Contributors:
+ *   Zowe Community
+ *   IBA Group
+ *   Uladzislau Kalesnikau
+ */
+
+package tests.utils.uidefinitions
+
+import com.intellij.driver.client.Driver
+import com.intellij.driver.sdk.ui.components.*
+import tests.utils.*
+import tests.utils.uidefinitions.dialogs.AddConnectionDialog
+import tests.utils.uidefinitions.dialogs.ErrorCreatingConnectionDialog
+import tests.utils.uidefinitions.dialogs.UnsecureConnectionDialog
+
+/** JES explorer panel wrapper. Provides functionalities to work with JES Explorer view elements */
+class JesExplorerPanel(val driver: Driver) {
+
+  lateinit var explorerView: UiComponent
+  lateinit var plusDropdownList: JListUiComponent
+
+  val plusButton by lazy { explorerView.actionButton { byAttribute("myicon", "add.svg") } }
+
+  init {
+    openJesExplorerTab(driver)
+    driver.ideFrame {
+      explorerView = x("//div[@class='SimpleToolWindowPanel' and div[@class='JesExplorerView']]")
+      plusDropdownList = popup().list { byClass("MyList") }
+    }
+  }
+
+  /**
+   * Open a respective dialog by the "+" button in JES explorer view
+   * @param point the menu point to select
+   */
+  fun openDialogByPlusButtonInExplorer(point: ActionMenuPoints) {
+    plusButton.click()
+    if (
+      point == ActionMenuPoints.CONNECTION ||
+      point == ActionMenuPoints.JES_WORKING_SET
+    ) {
+      plusDropdownList.clickItem(point.point)
+    } else {
+      throw IllegalArgumentException("Unsupported point for JES Explorer: $point")
+    }
+  }
+
+  /**
+   * Create a valid connection in a JES Explorer view
+   * @param ideDriver the IDE driver to work with other components
+   * @param connectionName the connection name to use
+   * @param scheme the HTTP scheme to use in the connection
+   * @param host the host to connect to
+   * @param port the port to connect to
+   * @param username the username to connect to the server with
+   * @param password the password to connect to the server with
+   * @param isAllowSelfSignedStr if "true", the "Allow self-signed certificates" option will be marked
+   */
+  fun createValidConnection(
+    ideDriver: Driver,
+    connectionName: String,
+    scheme: String = UI_TEST_HTTP_SCHEME,
+    host: String = UI_TEST_HOST,
+    port: String = UI_TEST_PORT,
+    username: String = UI_TEST_USERNAME,
+    password: String = UI_TEST_PASSWORD,
+    isAllowSelfSignedStr: String = UI_TEST_ALLOW_SELF_SIGNED
+  ) {
+    val jesExplorerPanel = JesExplorerPanel(ideDriver)
+    jesExplorerPanel.openDialogByPlusButtonInExplorer(ActionMenuPoints.CONNECTION)
+    val addConnectionDialog = AddConnectionDialog(ideDriver)
+    val unsecureConnectionDialog = UnsecureConnectionDialog(ideDriver)
+    val (url, isAllowSelfSigned) = prepareConnectionInfo(scheme, host, port, isAllowSelfSignedStr)
+    addConnectionDialog.fillDialog(connectionName, url, username, password, isAllowSelfSigned)
+    if (isAllowSelfSigned) {
+      unsecureConnectionDialog.proceedButton.click()
+    }
+    addConnectionDialog.okButton.click()
+    if (!url.contains("https") || isAllowSelfSigned) {
+      unsecureConnectionDialog.proceedButton.click()
+    }
+    // TODO: find a more suitable way to track the connection is checked
+    Thread.sleep(3000)
+  }
+
+  /**
+   * Create an invalid connection in a JES Explorer view
+   * @param ideDriver the IDE driver to work with other components
+   * @param connectionName the connection name to use
+   * @param scheme the HTTP scheme to use in the connection
+   * @param host the host to connect to
+   * @param port the port to connect to
+   * @param username the username to connect to the server with
+   * @param password the password to connect to the server with
+   * @param isAllowSelfSignedStr if "true", the "Allow self-signed certificates" option will be marked
+   */
+  fun createInvalidConnection(
+    connectionName: String,
+    ideDriver: Driver,
+    scheme: String = UI_TEST_HTTP_SCHEME,
+    host: String = UI_TEST_HOST,
+    port: String = UI_TEST_PORT,
+    username: String = UI_TEST_USERNAME,
+    password: String = UI_TEST_PASSWORD,
+    isAllowSelfSignedStr: String = UI_TEST_ALLOW_SELF_SIGNED
+  ) {
+    createValidConnection(ideDriver, connectionName, scheme, host, port, username, password, isAllowSelfSignedStr)
+    ErrorCreatingConnectionDialog(ideDriver).yesButton.click()
+  }
+}

--- a/src/uiTest/kotlin/tests/utils/uidefinitions/JesExplorerPanel.kt
+++ b/src/uiTest/kotlin/tests/utils/uidefinitions/JesExplorerPanel.kt
@@ -6,11 +6,6 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Copyright Contributors to the Zowe Project.
- *
- * Contributors:
- *   Zowe Community
- *   IBA Group
- *   Uladzislau Kalesnikau
  */
 
 package tests.utils.uidefinitions

--- a/src/uiTest/kotlin/tests/utils/uidefinitions/dialogs/AddConnectionDialog.kt
+++ b/src/uiTest/kotlin/tests/utils/uidefinitions/dialogs/AddConnectionDialog.kt
@@ -46,7 +46,7 @@ class AddConnectionDialog(val driver: Driver) {
 
   init {
     driver.ideFrame {
-      dialogComponent = dialog(title = "Add Connection")
+      dialogComponent = dialog("//div[@class='MyDialog' and (@title='Add Connection' or @title='Edit Connection')]")
     }
   }
 
@@ -78,5 +78,14 @@ class AddConnectionDialog(val driver: Driver) {
     assert(questionMark.isVisible())
     assert(cancelButton.isVisible())
   }
+
+  /** @return current value from "Connection name" field */
+  fun getConnectionNameValue(): String = connectionNameInput.text
+
+  /** @return current value from "Connection URL" field */
+  fun getConnectionUrlValue(): String = urlInput.text
+
+  /** @return current value from "Username" field */
+  fun getUsernameValue(): String = userNameInput.text
 
 }


### PR DESCRIPTION
## Summary
This PR implements my assigned UI test cases (Abdelrahman El Banna) for the Add Connection flow and extends UI test wrappers to support JES Explorer interactions.

## Changes Made
- Implemented assigned valid-connection scenarios in `AddConnectionDialogTest`
- Added reusable navigation helpers for opening specific Zowe Explorer tabs
- Updated `FilesExplorerPanel` to use explicit tab opening and extended supported action points
- Added new `JesExplorerPanel` wrapper (JES view interactions + connection creation helpers)
- Updated `AddConnectionDialog` locator to support both Add and Edit modes
- Added dialog field getter helpers used for assertion checks

## Validation
Executed:
`./gradlew uiTests --tests "tests.AddConnectionDialogTest" --stacktrace`

Result:
- `createValidConnectionTest` ✅ PASSED
- `editExistingConnectionTest` ⏭️ SKIPPED (`@Disabled`, assigned to another scenario owner)
- `createInvalidConnectionTest` ⏭️ SKIPPED (`@Disabled`, assigned to another scenario owner)

## Notes
- Branch: `codex/abdelrahman-ui-testcases`
- No direct changes to `main`
